### PR TITLE
Upgrade to gateway-api to v1.2.1 and add renovate to these crd resources

### DIFF
--- a/infratructure/kubernetes/talos/machine-config/control-plane.yaml.tftpl
+++ b/infratructure/kubernetes/talos/machine-config/control-plane.yaml.tftpl
@@ -18,12 +18,16 @@ cluster:
     disabled: true
   #need to install gateway api manifests before cilium deployment. GatewayClass acceptance 
   extraManifests:
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_gateways.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver 
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_backendlbpolicies.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
   inlineManifests:
   - name: cilium-values
     contents: |

--- a/kubernetes/infra/crds/kustomization.yaml
+++ b/kubernetes/infra/crds/kustomization.yaml
@@ -2,9 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_gateways.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver 
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.1/config/crd/experimental/gateway.networking.k8s.io_backendlbpolicies.yaml # renovate: github-tags=kubernetes-sigs/gateway-api versioning=semver


### PR DESCRIPTION
This pull request includes updates to the Kubernetes Gateway API manifests in the configuration files. The changes primarily involve updating the URLs to point to the newer version 1.2.1 of the Gateway API.

Updates to Gateway API manifests:

* [`infrastructure/kubernetes/talos/machine-config/control-plane.yaml.tftpl`](diffhunk://#diff-28def8bd9634664426669d8eef27e9e45ba75b8a4935c95174e0caf2d4941236L21-R30): Updated the URLs for the Gateway API manifests to version 1.2.1 and added comments for Renovate to manage versioning.
* [`kubernetes/infra/crds/kustomization.yaml`](diffhunk://#diff-a05262f3643d5aaf7fea9ea50aa5429b42b112bc56885b540048eae414ba1995L5-R14): Updated the URLs for the Gateway API manifests to version 1.2.1 and added comments for Renovate to manage versioning.